### PR TITLE
Add linter processing to autograder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ autograder
 cmake-build-debug
 .idea
 autograder.zip
+src/pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ autograder
 cmake-build-debug
 .idea
 autograder.zip
-src/pnpm-lock.yaml

--- a/src/clang-tidy
+++ b/src/clang-tidy
@@ -1,0 +1,37 @@
+Checks: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,-modernize-use-trailing-return-type'
+WarningsAsErrors: true
+HeaderFilterRegex: ''
+FormatStyle: google
+CheckOptions:
+  - key: cert-dcl16-c.NewSuffixes
+    value: 'L;LL;LU;LLU'
+  - key: cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: '0'
+  - key: cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: '1'
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: '1'
+  - key: google-readability-braces-around-statements.ShortStatementLines
+    value: '1'
+  - key: google-readability-function-size.StatementThreshold
+    value: '800'
+  - key: google-readability-namespace-comments.ShortNamespaceLines
+    value: '10'
+  - key: google-readability-namespace-comments.SpacesBeforeComments
+    value: '2'
+  - key: modernize-loop-convert.MaxCopySize
+    value: '16'
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-loop-convert.NamingStyle
+    value: CamelCase
+  - key: modernize-pass-by-value.IncludeStyle
+    value: llvm
+  - key: modernize-replace-auto-ptr.IncludeStyle
+    value: llvm
+  - key: modernize-use-nullptr.NullMacros
+    value: 'NULL'
+  - key: google-readability-todo
+    value: false
+  - key: clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferhandling
+    value: false

--- a/src/main.c
+++ b/src/main.c
@@ -8,43 +8,36 @@ bool is_first_test = true;
 
 void checkOneThing(char *test_name, bool assert, int points_possible, char *error_message){
     char output[300];
-    if (!is_first_test) {
+
+    if (!is_first_test)
+    {
         fprintf(result_file, ",\n");
-    } else{
+    }
+    else
+    {
+        fprintf(result_file, "[");
+
         is_first_test = false;
     }
-    if(assert) {
-        sprintf (output, "\t\t{\n"
-                         "\t\t\t\"score\": %d, \n"
-                         "\t\t\t\"max_score\": %d, \n"
-                         "\t\t\t\"status\": \"passed\", \n"
-                         "\t\t\t\"name\": \"%s\", \n"
-                         "\t\t\t\"name_format\": \"text\"\n"
-                         "\t\t}", points_possible, points_possible,test_name);
-    } else
+
+    if(assert)
     {
-        sprintf (output, "\t\t{\n"
-                         "\t\t\t\"score\": %d, \n"
-                         "\t\t\t\"max_score\": %d, \n"
-                         "\t\t\t\"status\": \"failed\", \n"
-                         "\t\t\t\"name\": \"%s\", \n"
-                         "\t\t\t\"name_format\": \"text\",\n "
-                         "\t\t\t\"output\": \"%s\""
-                         "\n\t\t}", 0, points_possible,test_name,error_message);
+        sprintf (output, "{\"score\": %d, \"max_score\": %d, \"status\": \"passed\", \"name\": \"%s\", \"name_format\": \"text\"}", points_possible, points_possible,test_name);
     }
+    else
+    {
+        sprintf (output, "{\"score\": %d, \"max_score\": %d, \"status\": \"failed\", \"name\": \"%s\", \"name_format\": \"text\", \"output\": \"%s\"}", 0, points_possible,test_name,error_message);
+    }
+
     fprintf( result_file, "%s", output );
 }
 
 int main() {
-
     result_file = fopen("output.json","w");
     assert(result_file != NULL);
 
-    fprintf(result_file, "{  \"visibility\": \"visible\", \n"
-                       "  \"stdout_visibility\": \"visible\", \n"
-                       "  \"tests\": [\n");
 #include "test_details.h"
-    fprintf(result_file, " ]}");
+    fprintf(result_file, "]");
     fclose(result_file);
     return 0;
 }

--- a/src/result_parser.py
+++ b/src/result_parser.py
@@ -1,0 +1,64 @@
+import json
+import sys
+import argparse
+
+from typing import Optional
+
+class TestResult:
+    def __init__(self, score: int, max_score: int, status: str, name: str, name_format: str, output: Optional[str] = None):
+        self.score = score
+        self.max_score = max_score
+        self.status = status
+        self.name = name
+        self.name_format = name_format
+        self.output = output
+
+class AutograderOutput:
+    def __init__(self, visibility: str, stdout_visibility: str, tests: list[TestResult]):
+        self.visibility = visibility
+        self.stdout_visibility = stdout_visibility
+        self.tests = tests
+
+# Initialize parser
+parser = argparse.ArgumentParser()
+
+# Adding optional argument
+parser.add_argument("-o", "--output", help = "Autograder output json file")
+parser.add_argument("-l", "--linter", help = "Linter output file")
+parser.add_argument("-lc", "--lintercode", help = "Linter code")
+parser.add_argument("-lp", "--linterpoints", help = "Linter points")
+
+# Read arguments from command line
+args = parser.parse_args()
+
+test_results = []
+
+with open(args.linter, 'r') as file:
+    test_results.append(TestResult(
+        score=int(args.linterpoints) if args.lintercode==0 else 0,
+        max_score=int(args.linterpoints),
+        status='passed' if args.lintercode==0 else 'failed',
+        name='Linter',
+        name_format='text',
+        output=file.read()
+    ))
+
+with open(args.output, 'r') as file:
+    data = json.loads(file.read())
+
+    for test in data:
+        test_results.append(TestResult(
+            score=test['score'],
+            max_score=test['max_score'],
+            status=test['status'],
+            name=test['name'],
+            name_format=test['name_format'],
+            output=test.get('output')
+        ))
+
+    output = AutograderOutput("visible", "visible", test_results)
+
+    print(json.dumps(output, default=lambda o: o.__dict__, indent=4))
+
+
+

--- a/src/run_autograder
+++ b/src/run_autograder
@@ -25,6 +25,3 @@ python3 result_parser.py \
   --linter clang_tidy_output.txt \
   --lintercode $lintercode \
   --linterpoints 5 > ../results/results.json
-
-#cp output.json ../results/results.json
-

--- a/src/run_autograder
+++ b/src/run_autograder
@@ -5,6 +5,8 @@ mkdir build
 (cd ./source && cp -r . ../build)
 (cd ./submission && cp -r . ../build)
 
+ls ./submission > submission_files.txt
+
 cd build
 
 make > build_output.txt 2>&1 || {
@@ -15,5 +17,14 @@ make > build_output.txt 2>&1 || {
 
 ./runner
 
-cp output.json ../results/results.json
+clang-tidy --config-file=./clang-tidy -warnings-as-errors=* $(cat ../submission_files.txt) 2> /dev/null > clang_tidy_output.txt
+lintercode=$?
+
+python3 result_parser.py \
+  --output output.json \
+  --linter clang_tidy_output.txt \
+  --lintercode $lintercode \
+  --linterpoints 5 > ../results/results.json
+
+#cp output.json ../results/results.json
 

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 apt update
-apt install -y build-essential gcc make
+apt install -y build-essential gcc make python3 clang-tidy


### PR DESCRIPTION
This pull request includes several changes to enhance the codebase by adding new configurations, improving the test result parsing, and integrating a linter with the build process. The most important changes include adding a new `clang-tidy` configuration, refactoring the test result output, and updating the build script to include linter results.

### Configuration and Linter Integration:
* [`src/clang-tidy`](diffhunk://#diff-cc0cf4675af366476084b04f46263bd892b34f302ee26965ffafbca17152d744R1-R37): Added a new `clang-tidy` configuration with specific checks, warnings as errors, and various key-value options to customize the linter behavior.
* [`src/setup.sh`](diffhunk://#diff-86c26822e3157adc32d88428c0403c6ba5f690f2fa477a77c5e29c5a5df54ea2L4-R4): Updated the setup script to install `python3` and `clang-tidy` along with other essential build tools.

### Test Result Parsing:
* [`src/result_parser.py`](diffhunk://#diff-4231bebf1666bc9681a5cfe559f2bc2007fbd1a42f06672ff51caf693f14ead8R1-R64): Introduced a new Python script to parse test results and linter output, combining them into a single JSON output. This script uses the `argparse` module to handle command-line arguments and constructs the final JSON output.

### Build Script Enhancements:
* [`src/run_autograder`](diffhunk://#diff-42b931ebf79584cfaddd92b8ba114ce7fb28cbab00b4e695f4b1dfe87e3faa37R8-R9): Modified the build script to run `clang-tidy`, capture its output, and use the new `result_parser.py` script to generate the final results JSON file. [[1]](diffhunk://#diff-42b931ebf79584cfaddd92b8ba114ce7fb28cbab00b4e695f4b1dfe87e3faa37R8-R9) [[2]](diffhunk://#diff-42b931ebf79584cfaddd92b8ba114ce7fb28cbab00b4e695f4b1dfe87e3faa37L18-R29)

### Code Formatting:
* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L11-R40): Improved code readability by reformatting the `checkOneThing` function, including consistent use of braces and simplifying the JSON output formatting.